### PR TITLE
generate text summaries for each Senzing entity

### DIFF
--- a/country.tsv
+++ b/country.tsv
@@ -1,0 +1,519 @@
+code	country
+ABW	Aruba
+AFG	Afghanistan
+AGO	Angola
+AIA	Anguilla
+ALA	Åland Islands
+ALB	Albania
+AND	Andorra
+ARE	United Arab Emirates
+ARG	Argentina
+ARM	Armenia
+ASM	American Samoa
+ATA	Antarctica
+ATF	French Southern Territories
+ATG	Antigua and Barbuda
+AUS	Australia
+AUT	Austria
+AZE	Azerbaijan
+BDI	Burundi
+BEL	Belgium
+BEN	Benin
+BES	Bonaire, Sint Eustatius and Saba
+BFA	Burkina Faso
+BGD	Bangladesh
+BGR	Bulgaria
+BHR	Bahrain
+BHS	Bahamas
+BIH	Bosnia and Herzegovina
+BLM	Saint Barthélemy
+BLR	Belarus
+BLZ	Belize
+BMU	Bermuda
+BOL	Bolivia
+BRA	Brazil
+BRB	Barbados
+BRN	Brunei Darussalam
+BTN	Bhutan
+BVT	Bouvet Island
+BWA	Botswana
+CAF	Central African Republic
+CAN	Canada
+CCK	Cocos (Keeling) Islands
+CHE	Switzerland
+CHL	Chile
+CHN	China
+CIV	Côte d'Ivoire
+CMR	Cameroon
+COD	Democratic Republic of the Congo
+COG	Congo
+COK	Cook Islands
+COL	Colombia
+COM	Comoros
+CPV	Cabo Verde
+CRI	Costa Rica
+CUB	Cuba
+CUW	Curaçao
+CXR	Christmas Island
+CYM	Cayman Islands
+CYP	Cyprus
+CZE	Czechia
+DEU	Germany
+DJI	Djibouti
+DMA	Dominica
+DNK	Denmark
+DOM	Dominican Republic
+DZA	Algeria
+ECU	Ecuador
+EGY	Egypt
+ERI	Eritrea
+ESH	Western Sahara
+ESP	Spain
+EST	Estonia
+ETH	Ethiopia
+FIN	Finland
+FJI	Fiji
+FLK	Falkland Islands (Malvinas)
+FRA	France
+FRO	Faroe Islands
+FSM	Micronesia
+GAB	Gabon
+GBR	United Kingdom
+GEO	Georgia
+GGY	Guernsey
+GHA	Ghana
+GIB	Gibraltar
+GIN	Guinea
+GLP	Guadeloupe
+GMB	Gambia
+GNB	Guinea-Bissau
+GNQ	Equatorial Guinea
+GRC	Greece
+GRD	Grenada
+GRL	Greenland
+GTM	Guatemala
+GUF	French Guiana
+GUM	Guam
+GUY	Guyana
+HKG	Hong Kong
+HMD	Heard Island and McDonald Islands
+HND	Honduras
+HRV	Croatia
+HTI	Haiti
+HUN	Hungary
+IDN	Indonesia
+IMN	Isle of Man
+IND	India
+IOT	British Indian Ocean Territory
+IRL	Ireland
+IRN	Iran
+IRQ	Iraq
+ISL	Iceland
+ISR	Israel
+ITA	Italy
+JAM	Jamaica
+JEY	Jersey
+JOR	Jordan
+JPN	Japan
+KAZ	Kazakhstan
+KEN	Kenya
+KGZ	Kyrgyzstan
+KHM	Cambodia
+KIR	Kiribati
+KNA	Saint Kitts and Nevis
+KOR	South Korea
+KWT	Kuwait
+LAO	Lao People's Democratic Republic
+LBN	Lebanon
+LBR	Liberia
+LBY	Libya
+LCA	Saint Lucia
+LIE	Liechtenstein
+LKA	Sri Lanka
+LSO	Lesotho
+LTU	Lithuania
+LUX	Luxembourg
+LVA	Latvia
+MAC	Macao
+MAF	Saint Martin
+MAR	Morocco
+MCO	Monaco
+MDA	Moldova
+MDG	Madagascar
+MDV	Maldives
+MEX	Mexico
+MHL	Marshall Islands
+MKD	North Macedonia
+MLI	Mali
+MLT	Malta
+MMR	Myanmar
+MNE	Montenegro
+MNG	Mongolia
+MNP	Northern Mariana Islands
+MOZ	Mozambique
+MRT	Mauritania
+MSR	Montserrat
+MTQ	Martinique
+MUS	Mauritius
+MWI	Malawi
+MYS	Malaysia
+MYT	Mayotte
+NAM	Namibia
+NCL	New Caledonia
+NER	Niger
+NFK	Norfolk Island
+NGA	Nigeria
+NIC	Nicaragua
+NIU	Niue
+NLD	Netherlands
+NOR	Norway
+NPL	Nepal
+NRU	Nauru
+NZL	New Zealand
+OMN	Oman
+PAK	Pakistan
+PAN	Panama
+PCN	Pitcairn
+PER	Peru
+PHL	Philippines
+PLW	Palau
+PNG	Papua New Guinea
+POL	Poland
+PRI	Puerto Rico
+PRK	North Korea
+PRT	Portugal
+PRY	Paraguay
+PSE	Palestine
+PYF	French Polynesia
+QAT	Qatar
+REU	Réunion
+ROU	Romania
+RUS	Russian Federation
+RWA	Rwanda
+SAU	Saudi Arabia
+SDN	Sudan
+SEN	Senegal
+SGP	Singapore
+SGS	South Georgia and the South Sandwich Islands
+SHN	Saint Helena, Ascension and Tristan da Cunha
+SJM	Svalbard and Jan Mayen
+SLB	Solomon Islands
+SLE	Sierra Leone
+SLV	El Salvador
+SMR	San Marino
+SOM	Somalia
+SPM	Saint Pierre and Miquelon
+SRB	Serbia
+SSD	South Sudan
+STP	Sao Tome and Principe
+SUR	Suriname
+SVK	Slovakia
+SVN	Slovenia
+SWE	Sweden
+SWZ	Eswatini
+SXM	Sint Maarten
+SYC	Seychelles
+SYR	Syrian Arab Republic
+TCA	Turks and Caicos Islands
+TCD	Chad
+TGO	Togo
+THA	Thailand
+TJK	Tajikistan
+TKL	Tokelau
+TKM	Turkmenistan
+TLS	Timor-Leste
+TON	Tonga
+TTO	Trinidad and Tobago
+TUN	Tunisia
+TUR	Türkiye
+TUV	Tuvalu
+TWN	Taiwan
+TZA	Tanzania
+UGA	Uganda
+UKR	Ukraine
+UMI	United States Minor Outlying Islands
+URY	Uruguay
+USA	United States
+UZB	Uzbekistan
+VAT	Holy See
+VCT	Saint Vincent and the Grenadines
+VEN	Venezuela
+VGB	British Virgin Islands
+BVI	British Virgin Islands
+VIR	U.S. Virgin Islands
+VNM	Viet Nam
+VUT	Vanuatu
+WLF	Wallis and Futuna
+WSM	Samoa
+YEM	Yemen
+ZAF	South Africa
+ZMB	Zambia
+ZWE	Zimbabwe
+AF	Afghanistan
+AL	Albania
+DZ	Algeria
+AS	American Samoa
+AD	Andorra
+AO	Angola
+AI	Anguilla
+AQ	Antarctica
+AG	Antigua and Barbuda
+AR	Argentina
+AM	Armenia
+AW	Aruba
+AU	Australia
+AT	Austria
+AZ	Azerbaijan
+BS	Bahamas
+BH	Bahrain
+BD	Bangladesh
+BB	Barbados
+BY	Belarus
+BE	Belgium
+BZ	Belize
+BJ	Benin
+BM	Bermuda
+BT	Bhutan
+BO	Bolivia
+BQ	Bonaire, Sint Eustatius and Saba
+BA	Bosnia and Herzegovina
+BW	Botswana
+BV	Bouvet Island
+BR	Brazil
+IO	British Indian Ocean Territory
+BN	Brunei Darussalam
+BG	Bulgaria
+BF	Burkina Faso
+BI	Burundi
+KH	Cambodia
+CM	Cameroon
+CA	Canada
+CV	Cape Verde
+KY	Cayman Islands
+CF	Central African Republic
+TD	Chad
+CL	Chile
+CN	China
+CX	Christmas Island
+CC	Cocos (Keeling) Islands
+CO	Colombia
+KM	Comoros
+CG	Congo
+CD	Democratic Republic of the Congo
+CK	Cook Islands
+CR	Costa Rica
+HR	Croatia
+CU	Cuba
+CW	Curaçao
+CY	Cyprus
+CZ	Czech Republic
+CI	Côte d'Ivoire
+DK	Denmark
+DJ	Djibouti
+DM	Dominica
+DO	Dominican Republic
+EC	Ecuador
+EG	Egypt
+SV	El Salvador
+GQ	Equatorial Guinea
+ER	Eritrea
+EE	Estonia
+ET	Ethiopia
+FK	Falkland Islands (Malvinas)
+FO	Faroe Islands
+FJ	Fiji
+FI	Finland
+FR	France
+GF	French Guiana
+PF	French Polynesia
+TF	French Southern Territories
+GA	Gabon
+GM	Gambia
+GE	Georgia
+DE	Germany
+GH	Ghana
+GI	Gibraltar
+GR	Greece
+GL	Greenland
+GD	Grenada
+GP	Guadeloupe
+GU	Guam
+GT	Guatemala
+GG	Guernsey
+GN	Guinea
+GW	Guinea-Bissau
+GY	Guyana
+HT	Haiti
+HM	Heard Island and McDonald Islands
+VA	Holy See (Vatican City State)
+HN	Honduras
+HK	Hong Kong
+HU	Hungary
+IS	Iceland
+IN	India
+ID	Indonesia
+IR	Iran
+IQ	Iraq
+IE	Ireland
+IM	Isle of Man
+IL	Israel
+IT	Italy
+JM	Jamaica
+JP	Japan
+JE	Jersey
+JO	Jordan
+KZ	Kazakhstan
+KE	Kenya
+KI	Kiribati
+KP	North Korea
+KR	South Korea
+KW	Kuwait
+KG	Kyrgyzstan
+LA	Lao People's Democratic Republic
+LV	Latvia
+LB	Lebanon
+LS	Lesotho
+LR	Liberia
+LY	Libya
+LI	Liechtenstein
+LT	Lithuania
+LU	Luxembourg
+MO	Macao
+MK	Macedonia
+MG	Madagascar
+MW	Malawi
+MY	Malaysia
+MV	Maldives
+ML	Mali
+MT	Malta
+MH	Marshall Islands
+MQ	Martinique
+MR	Mauritania
+MU	Mauritius
+YT	Mayotte
+MX	Mexico
+FM	Micronesia
+MD	Moldova
+MC	Monaco
+MN	Mongolia
+ME	Montenegro
+MS	Montserrat
+MA	Morocco
+MZ	Mozambique
+MM	Myanmar
+NA	Namibia
+NR	Nauru
+NP	Nepal
+NL	Netherlands
+NC	New Caledonia
+NZ	New Zealand
+NI	Nicaragua
+NE	Niger
+NG	Nigeria
+NU	Niue
+NF	Norfolk Island
+MP	Northern Mariana Islands
+NO	Norway
+OM	Oman
+PK	Pakistan
+PW	Palau
+PS	Palestine,
+PA	Panama
+PG	Papua New Guinea
+PY	Paraguay
+PE	Peru
+PH	Philippines
+PN	Pitcairn
+PL	Poland
+PT	Portugal
+PR	Puerto Rico
+QA	Qatar
+RO	Romania
+RU	Russian Federation
+RW	Rwanda
+RE	Réunion
+BL	Saint Barthélemy
+SH	Saint Helena, Ascension and Tristan da Cunha
+KN	Saint Kitts and Nevis
+LC	Saint Lucia
+MF	Saint Martin
+PM	Saint Pierre and Miquelon
+VC	Saint Vincent and the Grenadines
+WS	Samoa
+SM	San Marino
+ST	Sao Tome and Principe
+SA	Saudi Arabia
+SN	Senegal
+RS	Serbia
+SC	Seychelles
+SL	Sierra Leone
+SG	Singapore
+SX	Sint Maarten
+SK	Slovakia
+SI	Slovenia
+SB	Solomon Islands
+SO	Somalia
+ZA	South Africa
+GS	South Georgia and the South Sandwich Islands
+SS	South Sudan
+ES	Spain
+LK	Sri Lanka
+SD	Sudan
+SR	Suriname
+SJ	Svalbard and Jan Mayen
+SZ	Swaziland
+SE	Sweden
+CH	Switzerland
+SY	Syrian Arab Republic
+TW	Taiwan
+TJ	Tajikistan
+TZ	Tanzania
+TH	Thailand
+TL	Timor-Leste
+TG	Togo
+TK	Tokelau
+TO	Tonga
+TT	Trinidad and Tobago
+TN	Tunisia
+TR	Turkey
+TM	Turkmenistan
+TC	Turks and Caicos Islands
+TV	Tuvalu
+UG	Uganda
+UA	Ukraine
+AE	United Arab Emirates
+GB	United Kingdom
+UK	United Kingdom
+US	United States
+UM	United States Minor Outlying Islands
+UY	Uruguay
+UZ	Uzbekistan
+VU	Vanuatu
+VE	Venezuela
+VN	Viet Nam
+VG	British Virgin Islands
+VI	U.S. Virgin Islands
+WF	Wallis and Futuna
+EH	Western Sahara
+YE	Yemen
+ZM	Zambia
+ZW	Zimbabwe
+AX	Åland Islands
+MALAY	Malaysia
+IRELD	Ireland
+BERMU	Bermuda
+VANU	Vanuatu
+CHINA	China
+NETH	Netherlands
+CAYMN	Cayman Islands
+NEV	Saint Kitts and Nevis
+COOK	Cook Islands
+ZAM	Zambia
+NIUE	Niue
+BAH	Bahamas
+ANG	Hong Kong
+PMA	Uruguay
+SEY	Seychelles
+SAM	Taiwan
+MAURI	Mauritius
+LABUA	Malaysia

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,11 @@ requests = "^2.32.3"
 tqdm = "^4.66.5"
 graphdatascience = "^1.11"
 python-dotenv = "^1.0.1"
-
+icecream = "^2.1"
+ipywidgets = "^8.1"
+jupyterlab = "^4.2"
+jupyterlab_execute_time = "^3.1"
+watermark = "^2.4"
 
 [tool.poetry.group.dev.dependencies]
 notebook = "^7.2.2"

--- a/summaries.ipynb
+++ b/summaries.ipynb
@@ -1,0 +1,433 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7c19b3ab-3c1c-4eaf-b1b3-0c42876480e7",
+   "metadata": {},
+   "source": [
+    "## Generate summary text descriptions for each Senzing entity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acca0b7a-694f-4ace-bf7c-a601004bb93f",
+   "metadata": {},
+   "source": [
+    "load the dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f162dcc0-eb0e-46b2-9cce-c09be83c6c00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:02:53.057781Z",
+     "iopub.status.busy": "2024-09-28T05:02:53.057577Z",
+     "iopub.status.idle": "2024-09-28T05:02:53.091621Z",
+     "shell.execute_reply": "2024-09-28T05:02:53.091383Z",
+     "shell.execute_reply.started": "2024-09-28T05:02:53.057760Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "import json\n",
+    "import pathlib\n",
+    "import re\n",
+    "import typing\n",
+    "\n",
+    "from icecream import ic\n",
+    "import watermark\n",
+    "\n",
+    "%load_ext watermark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7c096cd0-a915-4987-9861-0f6d7e90abaa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:02:53.091964Z",
+     "iopub.status.busy": "2024-09-28T05:02:53.091901Z",
+     "iopub.status.idle": "2024-09-28T05:02:53.101679Z",
+     "shell.execute_reply": "2024-09-28T05:02:53.101221Z",
+     "shell.execute_reply.started": "2024-09-28T05:02:53.091954Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Last updated: 2024-09-27T22:02:53.092436-07:00\n",
+      "\n",
+      "Python implementation: CPython\n",
+      "Python version       : 3.12.4\n",
+      "IPython version      : 8.27.0\n",
+      "\n",
+      "Compiler    : Clang 15.0.0 (clang-1500.3.9.4)\n",
+      "OS          : Darwin\n",
+      "Release     : 23.6.0\n",
+      "Machine     : arm64\n",
+      "Processor   : arm\n",
+      "CPU cores   : 14\n",
+      "Architecture: 64bit\n",
+      "\n",
+      "watermark: 2.5.0\n",
+      "re       : 2.2.1\n",
+      "csv      : 1.0\n",
+      "json     : 2.0.9\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark\n",
+    "%watermark --iversions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e2721cf-6741-4ad2-b431-961019b36cb4",
+   "metadata": {},
+   "source": [
+    "load the Senzing export JSON"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fbe0b8b9-4fe2-4abe-b658-1b431825f64c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:02:53.102489Z",
+     "iopub.status.busy": "2024-09-28T05:02:53.102366Z",
+     "iopub.status.idle": "2024-09-28T05:02:53.104901Z",
+     "shell.execute_reply": "2024-09-28T05:02:53.104564Z",
+     "shell.execute_reply.started": "2024-09-28T05:02:53.102470Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "icij_path: pathlib.Path = pathlib.Path(\"ICIJ-entity-report-2024-06-21_12-04-57-std.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "93fba71c-055d-4f36-878c-01027467ec8a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:02:53.105493Z",
+     "iopub.status.busy": "2024-09-28T05:02:53.105399Z",
+     "iopub.status.idle": "2024-09-28T05:03:09.267512Z",
+     "shell.execute_reply": "2024-09-28T05:03:09.267176Z",
+     "shell.execute_reply.started": "2024-09-28T05:02:53.105485Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ents: dict = {}\n",
+    "\n",
+    "with icij_path.open(encoding = \"utf-8\") as fp:\n",
+    "    while line := fp.readline():\n",
+    "        dat = json.loads(line.strip())\n",
+    "        ent: dict = dat[\"RESOLVED_ENTITY\"]\n",
+    "\n",
+    "        ent_id: str = ent[\"ENTITY_ID\"]\n",
+    "\n",
+    "        features: dict = {\n",
+    "            key: feature[0][\"FEAT_DESC\"]\n",
+    "            for key, feature in ent[\"FEATURES\"].items()\n",
+    "        }\n",
+    "\n",
+    "        ents[ent_id] = features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "715ddc56-ae73-4c4d-a3ca-8f690b4a701b",
+   "metadata": {},
+   "source": [
+    "enumerate the features available on entities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2cf1e93c-f021-4eb2-94b9-cf75118db29e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:03:09.268033Z",
+     "iopub.status.busy": "2024-09-28T05:03:09.267949Z",
+     "iopub.status.idle": "2024-09-28T05:03:09.661576Z",
+     "shell.execute_reply": "2024-09-28T05:03:09.661349Z",
+     "shell.execute_reply.started": "2024-09-28T05:03:09.268024Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ADDRESS',\n",
+       " 'COUNTRY_OF_ASSOCIATION',\n",
+       " 'DOB',\n",
+       " 'DUNS_NUMBER',\n",
+       " 'GROUP_ASSOCIATION',\n",
+       " 'NAME',\n",
+       " 'PHONE',\n",
+       " 'RECORD_TYPE',\n",
+       " 'REL_ANCHOR',\n",
+       " 'REL_POINTER',\n",
+       " 'WEBSITE'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "feats: set = set()\n",
+    "\n",
+    "for ent_feat in ents.values():\n",
+    "    feats |= ent_feat.keys()\n",
+    "\n",
+    "feats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f713360-8bd5-4d18-a40a-1768c0133a6e",
+   "metadata": {},
+   "source": [
+    "load the country codes used within the ICIJ Offshore Leaks dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f82b8a10-975a-4805-8008-64a94830e70b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:03:09.662835Z",
+     "iopub.status.busy": "2024-09-28T05:03:09.662769Z",
+     "iopub.status.idle": "2024-09-28T05:03:09.665071Z",
+     "shell.execute_reply": "2024-09-28T05:03:09.664863Z",
+     "shell.execute_reply.started": "2024-09-28T05:03:09.662829Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "COUNTRIES: dict = {}\n",
+    "\n",
+    "cc_file = \"country.tsv\"\n",
+    "\n",
+    "with open(cc_file, \"r\", encoding = \"utf-8\") as fp:\n",
+    "    tsv_reader = csv.reader(fp, delimiter = \"\\t\")\n",
+    "    next(tsv_reader, None)  # skip the header row\n",
+    "    \n",
+    "    COUNTRIES = {\n",
+    "        row[0]: row[1]\n",
+    "        for row in tsv_reader\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def get_country (\n",
+    "    code: typing.Optional[ str ],\n",
+    "    ) -> typing.Optional[ str ]:\n",
+    "    \"\"\"\n",
+    "Map from a country code to a full name.\n",
+    "    \"\"\"\n",
+    "    if code is None:\n",
+    "        return None\n",
+    "\n",
+    "    return COUNTRIES.get(code.strip())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66ced55c-5e98-42a4-8381-b8d588151d84",
+   "metadata": {},
+   "source": [
+    "prepare to filter out anonymized names on bearer shares, e.g., \"The Bearer\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5984b5ea-30fb-4318-a7f1-fdce7321ef4f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:03:09.665499Z",
+     "iopub.status.busy": "2024-09-28T05:03:09.665422Z",
+     "iopub.status.idle": "2024-09-28T05:03:09.667235Z",
+     "shell.execute_reply": "2024-09-28T05:03:09.667062Z",
+     "shell.execute_reply.started": "2024-09-28T05:03:09.665490Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "PAT_LIST: typing.List[ str ] = [\n",
+    "    r\"^\\-?(to\\s+)?([the]+\\s+)?bearer\\.?\\s?(\\d+)?(\\w)?$\",\n",
+    "    r\"^.*bearer.*shares?$\",\n",
+    "    r\"^the\\s+bearer\\s+\\([\\d\\,]+\\)$\",\n",
+    "    r\"^[ae]l\\s+portador$\",\n",
+    "    r\"^the\\s?bearer$\",\n",
+    "    r\"^bearer\\s?warrant$\",\n",
+    "    r\"^bearer\\s?shareholder$\",\n",
+    "    r\"^the\\,\\s+bearer$\",\n",
+    "    r\"^bearer\\s+\\(reedeem\\s+shares\\)$\",\n",
+    "    r\"^the\\s+bearer\\s+\\(lost\\)$\",\n",
+    "    r\"^bearer\\s+\\-\\s+[\\w]$\",\n",
+    "    r\"^bearer\\s+\\\"\\w\\\"$\",\n",
+    "    r\"^bearer\\s+[\\d\\-]+$\",\n",
+    "    r\"^bearer\\s+no\\.\\s+\\d+$\",\n",
+    "    r\"^the\\s+bearer\\s+at\\s+[\\d\\,]+$\",\n",
+    "    r\"^nan$\",\n",
+    "    r\"^[\\?]+$\",\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def filter_bearer (\n",
+    "    name: str,\n",
+    "    ) -> bool:\n",
+    "    \"\"\"\n",
+    "These names are used to hide the identity of a company shareholder.\n",
+    "    \"\"\"\n",
+    "    name = str(name).lower()\n",
+    "\n",
+    "    for pat in PAT_LIST:\n",
+    "        if re.search(pat, name) is not None:\n",
+    "            return False\n",
+    "\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9dfe63c-0b2a-4b89-8356-a20547e92b5f",
+   "metadata": {},
+   "source": [
+    "generate a summary description for each entity in the Senzing export"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ef733f92-e86f-450b-b4ba-da506b4df8e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:03:09.667562Z",
+     "iopub.status.busy": "2024-09-28T05:03:09.667504Z",
+     "iopub.status.idle": "2024-09-28T05:03:15.572969Z",
+     "shell.execute_reply": "2024-09-28T05:03:15.572626Z",
+     "shell.execute_reply.started": "2024-09-28T05:03:09.667556Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "summaries: dict = {}\n",
+    "\n",
+    "for ent_id, ent_feat in ents.items():\n",
+    "    if \"NAME\" in ent_feat:\n",
+    "        text: str = ent_feat.get(\"NAME\")\n",
+    "        \n",
+    "        if filter_bearer(text.strip()):\n",
+    "            kind: str = ent_feat.get(\"RECORD_TYPE\")\n",
+    "\n",
+    "            if kind == \"ORGANIZATION\":\n",
+    "                if \"ADDRESS\" in ent_feat:\n",
+    "                    text += \", located at \" + ent_feat.get(\"ADDRESS\")\n",
+    "\n",
+    "                if \"DUNS_NUMBER\" in ent_feat:\n",
+    "                    text += \", DUNS \" + ent_feat.get(\"DUNS_NUMBER\")\n",
+    "\n",
+    "                if \"PHONE\" in ent_feat:\n",
+    "                    text += \", phone \" + ent_feat.get(\"PHONE\")\n",
+    "\n",
+    "                if \"COUNTRY_OF_ASSOCIATION\" in ent_feat:\n",
+    "                    country: typing.Optional[ str ] = get_country(ent_feat.get(\"COUNTRY_OF_ASSOCIATION\"))\n",
+    "\n",
+    "                    if country is not None:\n",
+    "                        text += \", in \" + country\n",
+    "\n",
+    "                if \"WEBSITE\" in ent_feat:\n",
+    "                    text += \", website \" + ent_feat.get(\"WEBSITE\")\n",
+    "\n",
+    "                summaries[ent_id] = text\n",
+    "\n",
+    "            elif kind == \"ORGANIZATION\":\n",
+    "                if \"DOB\" in ent_feat:\n",
+    "                    text += \", born \" + ent_feat.get(\"DOB\")\n",
+    "\n",
+    "                if \"PHONE\" in ent_feat:\n",
+    "                    text += \", phone \" + ent_feat.get(\"PHONE\")\n",
+    "\n",
+    "                if \"ADDRESS\" in ent_feat:\n",
+    "                    text += \", located at \" + ent_feat.get(\"ADDRESS\")\n",
+    "\n",
+    "                if \"GROUP_ASSOCIATION\" in ent_feat:\n",
+    "                    text += \", associated with \" + ent_feat.get(\"GROUP_ASSOCIATION\")\n",
+    "\n",
+    "                if \"COUNTRY_OF_ASSOCIATION\" in ent_feat:\n",
+    "                    country: typing.Optional[ str ] = get_country(ent_feat.get(\"COUNTRY_OF_ASSOCIATION\"))\n",
+    "\n",
+    "                    if country is not None:\n",
+    "                        text += \" in \" + country\n",
+    "\n",
+    "                summaries[ent_id] = text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e57c8aed-192a-4792-a0cf-1cb12dbbf7b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-09-28T05:03:15.573410Z",
+     "iopub.status.busy": "2024-09-28T05:03:15.573327Z",
+     "iopub.status.idle": "2024-09-28T05:03:16.596354Z",
+     "shell.execute_reply": "2024-09-28T05:03:16.596065Z",
+     "shell.execute_reply.started": "2024-09-28T05:03:15.573403Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "summ_path: pathlib.Path = pathlib.Path(\"summaries.tsv\")\n",
+    "\n",
+    "with open(summ_path, \"w\", encoding = \"utf-8\") as fp:\n",
+    "    writer = csv.writer(fp, delimiter = \"\\t\", lineterminator = \"\\n\")\n",
+    "    writer.writerow([ \"sz_ent_id\", \"summary\" ])\n",
+    "    \n",
+    "    for ent_id, summary in summaries.items():\n",
+    "        writer.writerow([ ent_id, summary ])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hi @louisguitton,

The `summaries.ipynb` notebook shows how to generate text summaries for each Senzing entity.

This depends on:

  * an inflated `ICIJ-entity-report-2024-06-21_12-04-57-std.json` file in the directory
  * `country.tsv` - country code mappings used in the ICIJ dataset

Note that any name such as "The Bearer" or "Al Portador" is an anonymized shareholder (given the bearer shares used for fraud in the dataset) so these are filtered out.

The results are in the `summaries.txt` file -- which is committed, although in the tutorial instead we would probably generate it as part of the article?

Will these text descriptions work well for the entity linker?